### PR TITLE
Add an example where documentation is generated using ocamldoc

### DIFF
--- a/examples/06-ocamldoc/Makefile
+++ b/examples/06-ocamldoc/Makefile
@@ -1,0 +1,53 @@
+#
+# Pure OCaml, no packages, no _tags, code in serveral directories
+# Targets starting with "doc_" generate documentation for the Util and Hello
+# modules
+#
+
+# bin-annot is required for Merlin and other IDE-like tools
+# The -I flag introduces sub-directories to search for code
+
+OCB_FLAGS = -tag bin_annot -I src -I lib
+OCB = 		ocamlbuild $(OCB_FLAGS)
+
+all: 		native byte # profile debug
+
+clean:
+			$(OCB) -clean
+
+native: 
+			$(OCB) main.native
+
+byte:
+			$(OCB) main.byte
+
+profile:
+			$(OCB) -tag profile main.native
+
+debug:
+			$(OCB) -tag debug main.byte
+
+doc_html:
+			$(OCB) doc/api.docdir/index.html
+
+doc_man:
+			$(OCB) doc/api.docdir/man
+
+doc_tex:
+# the name of the .tex file can be anything
+			$(OCB) doc/api.docdir/api.tex
+
+doc_texinfo:
+# the name of the .texi file can be anything
+			$(OCB) doc/api.docdir/api.texi
+
+doc_dot:
+# the .dot graph represents inter-module dependencies
+# as before, the name doesn't matter
+			$(OCB) doc/api.docdir/api.dot
+
+test: 		native
+			./main.native "OCaml" "OCamlBuild" "users"
+
+
+.PHONY: 	all clean byte native profile debug test

--- a/examples/06-ocamldoc/doc/api.odocl
+++ b/examples/06-ocamldoc/doc/api.odocl
@@ -1,0 +1,2 @@
+Hello
+Util

--- a/examples/06-ocamldoc/lib/hello.ml
+++ b/examples/06-ocamldoc/lib/hello.ml
@@ -1,0 +1,1 @@
+let hello = "Hello"

--- a/examples/06-ocamldoc/lib/hello.mli
+++ b/examples/06-ocamldoc/lib/hello.mli
@@ -1,0 +1,4 @@
+(** The hello module. *)
+
+(** A string mostly used as a greeting. *)
+val hello : string

--- a/examples/06-ocamldoc/lib/util.ml
+++ b/examples/06-ocamldoc/lib/util.ml
@@ -1,0 +1,8 @@
+
+let rec join = function
+  | []      -> ""
+  | [x]     -> x
+  | [x;y]   -> x ^ " and " ^ y
+  | x::xs   -> x ^ ", "    ^ join xs
+
+

--- a/examples/06-ocamldoc/lib/util.mli
+++ b/examples/06-ocamldoc/lib/util.mli
@@ -1,0 +1,5 @@
+(** A module containing some utility functions. *)
+
+(** join strings together using command and "and" for the last element *)
+val join: string list -> string
+

--- a/examples/06-ocamldoc/src/main.ml
+++ b/examples/06-ocamldoc/src/main.ml
@@ -1,0 +1,10 @@
+
+let main () =
+  let argv = Array.to_list Sys.argv in
+  let args = List.tl argv in
+  match args with
+  | []        -> Printf.printf "%s, world!\n" Hello.hello
+  | names     -> Printf.printf "%s, %s!\n" Hello.hello (Util.join names)
+
+let () = main ()        
+


### PR DESCRIPTION
I want to add an example of how to build with a custom ocamldoc plugin, but before that, we need an example using standard ocamldoc, IMO. Hence this PR.

Nb: the target for generating manpages does not work (never used that before myself, I just used the target from the manual). This should be fixed before merging, but I don't know how.